### PR TITLE
Docker: Use current dir context for container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   indexcards:
     container_name: indexcards
     image: indexcards:latest
+    build:
+      context: .
+      cache_from:
+        - indexcards:latest
     restart: always
     ports:
         - 9001:3000


### PR DESCRIPTION
This reduces the number of steps to set up the container, by having the Dockerfile be run during the `docker-compose up --build` command.

I'd also recommend including a `mysql` image as well to not have to have some components be run outside of Docker.
```yaml
  mysql:
    image: mysql:latest
    environment:
      MYSQL_DATABASE: tabroom
      MYSQL_ROOT_PASSWORD: root
      MYSQL_USER: tabroom
      MYSQL_PASSWORD: thisisadbpassword
    volumes:
      - /var/lib/mysql:/var/lib/mysql
    ports:
      - "3306:3306"
```