### PR TITLE
Move DB table naming to proper object

### DIFF
--- a/api/models/categorySetting.js
+++ b/api/models/categorySetting.js
@@ -1,6 +1,5 @@
 const categorySetting = (sequelize, DataTypes) => {
 	return sequelize.define('categorySetting', {
-		tableName: 'category_setting',
 		tag: {
 			type: DataTypes.STRING(32),
 			allowNull: false,
@@ -17,6 +16,8 @@ const categorySetting = (sequelize, DataTypes) => {
 			type: DataTypes.DATE,
 			allowNull: true,
 		},
+	}, {
+		tableName: 'category_setting',
 	});
 };
 

--- a/api/models/shift.js
+++ b/api/models/shift.js
@@ -8,7 +8,7 @@ const shift = (sequelize, DataTypes) => {
 		type: {
 			type: DataTypes.ENUM('signup', 'strike', 'both'),
 			allowNull: false,
-			defaultValue: 'string',
+			defaultValue: 'both',
 		},
 		start: {
 			type: DataTypes.DATE,

--- a/api/models/sweepAward.js
+++ b/api/models/sweepAward.js
@@ -1,6 +1,5 @@
 const sweepAward = (sequelize, DataTypes) => {
 	return sequelize.define('sweepAward', {
-		table: 'sweep_award',
 		name: {
 			type: DataTypes.STRING(127),
 			allowNull: false,
@@ -30,6 +29,8 @@ const sweepAward = (sequelize, DataTypes) => {
 			type: DataTypes.INTEGER(6),
 			allowNull: true,
 		},
+	}, {
+		tableName: 'sweep_award',
 	});
 };
 

--- a/api/models/sweepEvent.js
+++ b/api/models/sweepEvent.js
@@ -1,6 +1,5 @@
 const sweepEvent = (sequelize, DataTypes) => {
 	return sequelize.define('sweepEvent', {
-		table: 'sweep_event',
 		event_type: {
 			type: DataTypes.ENUM('all','congress','debate','speech','wsdc','wudc'),
 			allowNull: true,
@@ -9,6 +8,8 @@ const sweepEvent = (sequelize, DataTypes) => {
 			type: DataTypes.ENUM('all','open','jv','novice','champ','es-open','es-novice','middle'),
 			allowNull: true,
 		},
+	}, {
+		tableName: 'sweep_event',
 	});
 };
 


### PR DESCRIPTION
I was getting some errors when trying to create the DB schema due to invalid default values for non-nullable fields, and invalid SQL syntax due to the table name specification being treated as a column. This PR fixes these issues, but keeps the invalid dates as defaults on other tables.