### PR TITLE
tmpLabel may be undefined when page first loads

### DIFF
--- a/api/controllers/tab/round/index.js
+++ b/api/controllers/tab/round/index.js
@@ -139,7 +139,7 @@ export const roundDecisionStatus = {
 			2: tmplabel?.neg || 'N',
 		};
 
-		const eventType = tmplabel.eventType || 'debate';
+		const eventType = tmplabel?.eventType || 'debate';
 
 		const rawBallots = await db.sequelize.query(`
 			select


### PR DESCRIPTION
Seen an occasional blip on schematics that the status column is empty for a while with an error 

```
TypeError: Cannot read properties of undefined (reading 'eventType')\n    at GET (file:///indexcards/api/controllers/tab/round/index.js:142:30)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

I don't know this will fully fix it, but should help.