### PR TITLE
Add CORS_ORIGINS configuration option

### DIFF
--- a/config/config.sample.js
+++ b/config/config.sample.js
@@ -29,6 +29,7 @@ export const config = {
 	COOKIE_NAME           : 'TabroomLocal',
 	COOKIE_DOMAIN         : '.dev.tabroom.com',
 	SESSION_SHARED        : 'random_string',
+	CORS_ORIGINS		  : ['http://localhost:9000', 'https://localhost:9000'],
 	CSRF                  : {
 		COOKIE_NAME   : 'CSRF_Token',
 		HEADER_NAME   : 'x-csrf-token'


### PR DESCRIPTION
app.js is already looking for a CORS_ORIGINS variable; this change adds a default CORS_ORIGINS value based on the default port for schemats.

Without this, the frontend throws some 500 errors